### PR TITLE
docs: fixed link to complete API reference & guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ data_engine:
 
 | Resource | Description | Link |
 |----------|-------------|------|
-| **Documentation** | Complete API reference & guides | [docs](https://lukehinds.github.io/DeepFabric/) |
+| **Documentation** | Complete API reference & guides | [docs](https://lukehinds.github.io/deepfabric/) |
 | **Examples** | Ready-to-use configurations | [examples/](./examples/README.md) |
 | **Discord** | Community support | [Join Discord](https://discord.gg/pPcjYzGvbS) |
 | **Issues** | Bug reports & features | [GitHub Issues](https://github.com/lukehinds/deepfabric/issues) |


### PR DESCRIPTION
# **Description:**

Fixed broken documentation link in README.md that was pointing to the wrong URL path.
Issue - #342 

### Changes Made
- Updated documentation link from `lukehinds.github.io/DeepFabric/` to `lukehinds.github.io/deepfabric/` (corrected capitalization)

### Type of Change
- [x] Documentation fix
- [x] Bug fix 

### Impact
- Ensures users can properly access the complete API reference and guides
- Fixes 404 error when clicking documentation link in README

This is a small but important fix to ensure documentation accessibility for users.